### PR TITLE
switches activates on destructor call now

### DIFF
--- a/data/meta/enemy_charger.json
+++ b/data/meta/enemy_charger.json
@@ -139,6 +139,7 @@
 			"id": 2,
 			"friendly_fire": true
 		},
-		"C_Camera_Focus": {}
+		"C_Camera_Focus": {},
+		"C_Switch": {}
 	}
 }

--- a/data/meta/enemy_range.json
+++ b/data/meta/enemy_range.json
@@ -139,6 +139,7 @@
 			"id": 2,
 			"friendly_fire": true
 		},
-		"C_Camera_Focus": {}
+		"C_Camera_Focus": {},
+		"C_Switch": {}
 	}
 }

--- a/data/meta/lever_white.json
+++ b/data/meta/lever_white.json
@@ -30,8 +30,7 @@
 			]
 		},
 		"C_Switch": {
-			"mask": 1,
-			"is_multi_use": true,
+			"trigger_on_touch": true,
 			"reset_time": 5.0,
 		},
 		"C_Prop": {}

--- a/data/meta/pickup_ammunition.json
+++ b/data/meta/pickup_ammunition.json
@@ -33,6 +33,7 @@
 			"type": "ammunition",
 			"count": 5
 		},
+		"C_Switch": {},
 		"C_Prop": {}
 	}
 }

--- a/src/assets/assets.c
+++ b/src/assets/assets.c
@@ -614,6 +614,7 @@ void parse_component_switch(CF_JVal obj, Asset_Resource* resource)
     
     *c_switch = (C_Switch){
         .reset_time = JSON_GET_FLOAT(obj, "reset_time"),
+        .trigger_on_touch = JSON_GET_BOOL(obj, "trigger_on_touch"),
     };
     
     Property property = 
@@ -2318,7 +2319,6 @@ void load_level_version_2(u8* file, u8* data, u64 file_size, Load_Level_Result* 
     result->success = true;
 }
 
-//  @todo:  include switch links
 void load_level_version_3(u8* file, u8* data, u64 file_size, Load_Level_Result* result)
 {
     char* buf = scratch_alloc(1024);

--- a/src/game/editor_ui.c
+++ b/src/game/editor_ui.c
@@ -555,8 +555,7 @@ void editor_ui_do_switch_links()
                 Switch_Link* link = switch_links + index;
                 Switch_Link copy_link = *link;
                 b32 is_selected = link->state & Switch_Link_State_Bit_Editor_Select;
-                //  @hack:  we're using the 2nd bit of `is_filler` to determine if the thing should be shown to avoid
-                //          having to allocate a list of indices to show/hide the Switch_Link
+                
                 cf_string_fmt(buf, "%d", index);
                 if (game_ui_do_button_wide(buf))
                 {


### PR DESCRIPTION
`C_Switch` has a field `trigger_on_touch`, if this flag is off then it won't do any of the `on_touch` checks, this allows for `unit` or `pickup` and anything else that could have a `C_Switch` to trigger on destruction.
added `on_switch` event and all switch events are handled under `system_update_process_switch_queue()` previously it was called `system_update_tile_switches()`.

https://github.com/ogam/toy_iso_paintball/commit/a1c61ef9cf101bc97f16ef8c281cfa34ff5a33ea
above commit missed a few changes

ui now has input text for both s32 and f32 `ui_do_input_f32()` `ui_do_input_s32()` so this removed redundant and persistent strings that were part of `Game_UI`.
ui now has checkboxes.

saves are now on v3 to include `Switch_Link` change.
editor has support to undo/redo `Switch_Link`.
