### PR TITLE
removed hardcoded events from component structs

### DIFF
--- a/data/meta/baldy.json
+++ b/data/meta/baldy.json
@@ -46,55 +46,57 @@
 		"C_Emoter": {
 			"scale_x": 1.5,
 			"scale_y": 1.5,
-			"on_alert": {
-				"chance": 1.0,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "exclaimation"
-					}
-				]
-			},
-			"on_idle": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "drooling"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "sleepy"
-					}
-				]
-			},
-			"on_hit": {
-			},
-			"on_kill": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "cant"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "eager"
-					}
-				]
-			},
-			"on_dead": {
-				"chance": 0.8,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "angry"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "crying"
-					}
-				]
+			"events": {
+				"on_alert": {
+					"chance": 1.0,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "exclaimation"
+						}
+					]
+				},
+				"on_idle": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "drooling"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "sleepy"
+						}
+					]
+				},
+				"on_hit": {
+				},
+				"on_kill": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "cant"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "eager"
+						}
+					]
+				},
+				"on_dead": {
+					"chance": 0.8,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "angry"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "crying"
+						}
+					]
+				}
 			}
 		},
 		"C_Weapon": {
@@ -109,20 +111,22 @@
 		},
 		"C_Sound_Source": {
 			"type": "sfx",
-			"on_fire": [
-				"sfx/impactBell_heavy_004.ogg",
-				"sfx/impactGeneric_light_000.ogg",
-				"sfx/impactGeneric_light_001.ogg",
-				"sfx/impactGeneric_light_002.ogg",
-				"sfx/impactGeneric_light_003.ogg",
-				"sfx/impactGeneric_light_004.ogg"
-			],
-			"on_hit_taken": [
-			],
-			"on_dead": [
-				"sfx/footstep_carpet_003.ogg",
-				"sfx/footstep_carpet_004.ogg"
-			]
+			"events": {
+				"on_fire": [
+					"sfx/impactBell_heavy_004.ogg",
+					"sfx/impactGeneric_light_000.ogg",
+					"sfx/impactGeneric_light_001.ogg",
+					"sfx/impactGeneric_light_002.ogg",
+					"sfx/impactGeneric_light_003.ogg",
+					"sfx/impactGeneric_light_004.ogg"
+				],
+				"on_hit_taken": [
+				],
+				"on_dead": [
+					"sfx/footstep_carpet_003.ogg",
+					"sfx/footstep_carpet_004.ogg"
+				]
+			}
 		},
 		"C_UI": {
 			"select": {

--- a/data/meta/bounce_pad.json
+++ b/data/meta/bounce_pad.json
@@ -22,13 +22,6 @@
 			"scale_y": 1.5
 		},
 		"C_Elevation": {},
-		"C_Sound_Source": {
-			"type": "sfx",
-			"on_pickup": [
-				"sfx/clothBelt.ogg",
-				"sfx/clothBelt2.ogg"
-			]
-		},
 		"C_Bounce_Pad": {
 			"impulse": 5.0,
 			"restitution": 0.5

--- a/data/meta/enemy_charger.json
+++ b/data/meta/enemy_charger.json
@@ -57,55 +57,57 @@
 		"C_Emoter": {
 			"scale_x": 1.5,
 			"scale_y": 1.5,
-			"on_alert": {
-				"chance": 1.0,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "exclaimation"
-					}
-				]
-			},
-			"on_idle": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "drooling"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "sleepy"
-					}
-				]
-			},
-			"on_hit": {
-			},
-			"on_kill": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "cant"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "eager"
-					}
-				]
-			},
-			"on_dead": {
-				"chance": 0.8,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "angry"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "crying"
-					}
-				]
+			"events": {
+				"on_alert": {
+					"chance": 1.0,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "exclaimation"
+						}
+					]
+				},
+				"on_idle": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "drooling"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "sleepy"
+						}
+					]
+				},
+				"on_hit": {
+				},
+				"on_kill": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "cant"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "eager"
+						}
+					]
+				},
+				"on_dead": {
+					"chance": 0.8,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "angry"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "crying"
+						}
+					]
+				}
 			}
 		},
 		"C_Weapon": {
@@ -120,20 +122,22 @@
 		},
 		"C_Sound_Source": {
 			"type": "sfx",
-			"on_fire": [
-				"sfx/impactBell_heavy_004.ogg",
-				"sfx/impactGeneric_light_000.ogg",
-				"sfx/impactGeneric_light_001.ogg",
-				"sfx/impactGeneric_light_002.ogg",
-				"sfx/impactGeneric_light_003.ogg",
-				"sfx/impactGeneric_light_004.ogg"
-			],
-			"on_hit_taken": [
-			],
-			"on_dead": [
-				"sfx/footstep_carpet_003.ogg",
-				"sfx/footstep_carpet_004.ogg"
-			]
+			"events": {
+				"on_fire": [
+					"sfx/impactBell_heavy_004.ogg",
+					"sfx/impactGeneric_light_000.ogg",
+					"sfx/impactGeneric_light_001.ogg",
+					"sfx/impactGeneric_light_002.ogg",
+					"sfx/impactGeneric_light_003.ogg",
+					"sfx/impactGeneric_light_004.ogg"
+				],
+				"on_hit_taken": [
+				],
+				"on_dead": [
+					"sfx/footstep_carpet_003.ogg",
+					"sfx/footstep_carpet_004.ogg"
+				]
+			}
 		},
 		"C_Team": {
 			"id": 2,

--- a/data/meta/enemy_range.json
+++ b/data/meta/enemy_range.json
@@ -57,55 +57,57 @@
 		"C_Emoter": {
 			"scale_x": 1.5,
 			"scale_y": 1.5,
-			"on_alert": {
-				"chance": 1.0,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "exclaimation"
-					}
-				]
-			},
-			"on_idle": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "drooling"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "sleepy"
-					}
-				]
-			},
-			"on_hit": {
-			},
-			"on_kill": {
-				"chance": 0.3,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "cant"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "eager"
-					}
-				]
-			},
-			"on_dead": {
-				"chance": 0.8,
-				"emotes": [
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "angry"
-					},
-					{
-						"sprite": "sprites/emotes.ase",
-						"animation": "crying"
-					}
-				]
+			"events": {
+				"on_alert": {
+					"chance": 1.0,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "exclaimation"
+						}
+					]
+				},
+				"on_idle": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "drooling"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "sleepy"
+						}
+					]
+				},
+				"on_hit": {
+				},
+				"on_kill": {
+					"chance": 0.3,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "cant"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "eager"
+						}
+					]
+				},
+				"on_dead": {
+					"chance": 0.8,
+					"emotes": [
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "angry"
+						},
+						{
+							"sprite": "sprites/emotes.ase",
+							"animation": "crying"
+						}
+					]
+				}
 			}
 		},
 		"C_Weapon": {
@@ -120,20 +122,22 @@
 		},
 		"C_Sound_Source": {
 			"type": "sfx",
-			"on_fire": [
-				"sfx/impactBell_heavy_004.ogg",
-				"sfx/impactGeneric_light_000.ogg",
-				"sfx/impactGeneric_light_001.ogg",
-				"sfx/impactGeneric_light_002.ogg",
-				"sfx/impactGeneric_light_003.ogg",
-				"sfx/impactGeneric_light_004.ogg"
-			],
-			"on_hit_taken": [
-			],
-			"on_dead": [
-				"sfx/footstep_carpet_003.ogg",
-				"sfx/footstep_carpet_004.ogg"
-			]
+			"events": {
+				"on_fire": [
+					"sfx/impactBell_heavy_004.ogg",
+					"sfx/impactGeneric_light_000.ogg",
+					"sfx/impactGeneric_light_001.ogg",
+					"sfx/impactGeneric_light_002.ogg",
+					"sfx/impactGeneric_light_003.ogg",
+					"sfx/impactGeneric_light_004.ogg"
+				],
+				"on_hit_taken": [
+				],
+				"on_dead": [
+					"sfx/footstep_carpet_003.ogg",
+					"sfx/footstep_carpet_004.ogg"
+				]
+			}
 		},
 		"C_Team": {
 			"id": 2,

--- a/data/meta/lever_purple.json
+++ b/data/meta/lever_purple.json
@@ -22,13 +22,6 @@
 			"scale_y": 1.5
 		},
 		"C_Elevation": {},
-		"C_Sound_Source": {
-			"type": "sfx",
-			"on_pickup": [
-				"sfx/clothBelt.ogg",
-				"sfx/clothBelt2.ogg"
-			]
-		},
 		"C_Switch": {},
 		"C_Life_Time": {
 			"value": 2.0

--- a/data/meta/lever_white.json
+++ b/data/meta/lever_white.json
@@ -19,15 +19,31 @@
 				"default": "lever_white_off"
 			},
 			"scale_x": 1.5,
-			"scale_y": 1.5
+			"scale_y": 1.5,
+			"events": {
+				"on_switch": {
+					"sprite": "sprites/props.ase",
+					"animation": "lever_white_on"
+				},
+				"on_switch_reset": {
+					"sprite": "sprites/props.ase",
+					"animation": "lever_white_off"
+				}
+			}
 		},
 		"C_Elevation": {},
 		"C_Sound_Source": {
 			"type": "sfx",
-			"on_pickup": [
-				"sfx/clothBelt.ogg",
-				"sfx/clothBelt2.ogg"
-			]
+			"events": {
+				"on_switch": [
+					"sfx/clothBelt.ogg",
+					"sfx/clothBelt2.ogg"
+				],
+				"on_switch_reset": [
+					"sfx/clothBelt.ogg",
+					"sfx/clothBelt2.ogg"
+				]
+			}
 		},
 		"C_Switch": {
 			"trigger_on_touch": true,

--- a/data/meta/pickup_ammunition.json
+++ b/data/meta/pickup_ammunition.json
@@ -24,10 +24,12 @@
 		"C_Elevation": {},
 		"C_Sound_Source": {
 			"type": "sfx",
-			"on_pickup": [
-				"sfx/clothBelt.ogg",
-				"sfx/clothBelt2.ogg"
-			]
+			"events": {
+				"on_pickup": [
+					"sfx/clothBelt.ogg",
+					"sfx/clothBelt2.ogg"
+				]
+			}
 		},
 		"C_Pickup": {
 			"type": "ammunition",

--- a/data/meta/surface_icy.json
+++ b/data/meta/surface_icy.json
@@ -22,13 +22,6 @@
 			"scale_y": 1.5
 		},
 		"C_Elevation": {},
-		"C_Sound_Source": {
-			"type": "sfx",
-			"on_pickup": [
-				"sfx/clothBelt.ogg",
-				"sfx/clothBelt2.ogg"
-			]
-		},
 		"C_Surface_Icy": {},
 		"C_Prop": {}
 	}

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -185,6 +185,7 @@ fixed Asset_Resource** assets_get_resources_of_type(Asset_Resource_Type type);
 
 void* assets_get_resource_property_value(const char* name, const char* property_key);
 void* resource_get(Asset_Resource* resource, const char* name);
+cf_htbl struct Event_Reaction_Info** resource_get_event_reactions(Asset_Resource* resource);
 void property_copy_to(Property* property, void* data);
 
 // all fields are required except for @optional ones


### PR DESCRIPTION
added `Event_Reaction_Info` and entities with any events that needs to be handled (currently only `C_Sprite`, `C_Emoter` and `C_Sound_Source`) will be added to a list of event_reactions.
this cleans up a lot of hardcoded events like `on_pickup` and others that was part of `C_Emoter` and `C_Sound_Source`.
events can now update sprites, example being levers will turn on/off animation based off of `on_switch` and `on_switch_reset` events.
any other components that needs to handle an event in a specific way needs to update `resource_get_event_reactions()` hashtable with respective data associated with `Event_Reaction_Info`, see `parse_component_sprite()` `parse_component_emoter()` and `parse_component_sound_source` on how to handle supporting other components.