### PR TITLE
game input configs, fixed vfs mount leaks

### DIFF
--- a/src/assets/assets.c
+++ b/src/assets/assets.c
@@ -48,8 +48,22 @@ void mount_root_read_directory()
 void mount_root_write_directory()
 {
     char *path = mount_get_directory_path();
-    cf_string_append(path, "/");
     cf_fs_set_write_directory(path);
+    cf_string_free(path);
+}
+
+void dismount_data_directory()
+{
+    char *path = mount_get_directory_path();
+    cf_string_append(path, "/data");
+    cf_fs_dismount(path);
+    cf_string_free(path);
+}
+
+void dismount_root_directory()
+{
+    char *path = mount_get_directory_path();
+    cf_fs_dismount(path);
     cf_string_free(path);
 }
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -159,6 +159,8 @@ void mount_data_read_directory();
 void mount_data_write_directory();
 void mount_root_read_directory();
 void mount_root_write_directory();
+void dismount_data_directory();
+void dismount_root_directory();
 
 void assets_load_all();
 CF_Audio* assets_get_sound(const char* name);

--- a/src/game/editor.h
+++ b/src/game/editor.h
@@ -70,38 +70,20 @@ typedef struct Editor_Command
     };
 } Editor_Command;
 
-typedef s32 Input_Mod;
-enum
-{
-    Input_Mod_None = 0,
-    Input_Mod_Control = 1 << 0,
-    Input_Mod_Shift = 1 << 1,
-    Input_Mod_Alt = 1 << 2,
-    Input_Mod_Gui = 1 << 3,
-};
-
-typedef struct Input_Binding
-{
-    b32 is_mouse_button;
-    Input_Mod mod;
-    CF_KeyButton key;
-    CF_MouseButton mouse;
-} Input_Binding;
-
 typedef struct Editor_Input_Config
 {
-    dyna Input_Binding* place;
-    dyna Input_Binding* remove;
-    dyna Input_Binding* floodfill_mode;
-    dyna Input_Binding* brush_mode;
-    dyna Input_Binding* auto_tiling;
-    dyna Input_Binding* pan;
-    dyna Input_Binding* pan_up;
-    dyna Input_Binding* pan_down;
-    dyna Input_Binding* pan_left;
-    dyna Input_Binding* pan_right;
-    dyna Input_Binding* place_switch_link_stairs_top;
-    dyna Input_Binding* place_camera_tile;
+    dyna struct Input_Binding* place;
+    dyna struct Input_Binding* remove;
+    dyna struct Input_Binding* floodfill_mode;
+    dyna struct Input_Binding* brush_mode;
+    dyna struct Input_Binding* auto_tiling;
+    dyna struct Input_Binding* pan;
+    dyna struct Input_Binding* pan_up;
+    dyna struct Input_Binding* pan_down;
+    dyna struct Input_Binding* pan_left;
+    dyna struct Input_Binding* pan_right;
+    dyna struct Input_Binding* place_switch_link_stairs_top;
+    dyna struct Input_Binding* place_camera_tile;
 } Editor_Input_Config;
 
 typedef struct Editor_Input

--- a/src/game/entity.c
+++ b/src/game/entity.c
@@ -4941,12 +4941,11 @@ ecs_ret_t system_update_mover_navigation(ecs_t* ecs, ecs_id_t* entities, int ent
         b32 is_falling = (elevation->prev_value - elevation->value) > ELEVATION_FALL_THRESHOLD;
         mover->move_time = cf_clamp(mover->move_time - dt, 0.0f, mover->move_rate);
         
-        if (mover->is_pathing)
+        if (mover->move_time == 0.0f)
         {
-            if (mover->move_time == 0.0f)
+            unit_transform->prev_tile = unit_transform->tile;
+            if (mover->is_pathing)
             {
-                unit_transform->prev_tile = unit_transform->tile;
-                
                 if (cf_array_count(navigation->path) && navigation->path_index < cf_array_count(navigation->path))
                 {
                     V2i next_tile = navigation->path[navigation->path_index++];

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -5,6 +5,8 @@ typedef struct App
 {
     struct Assets* assets;
     struct Input* input;
+    struct Input_Config* input_config;
+    struct Input_Config* temp_input_config;
     struct Memory* memory;
     struct World* world;
     struct UI* ui;
@@ -38,7 +40,15 @@ typedef struct App
 void game_handle_window_state();
 void game_init();
 void game_deinit();
+
+void game_init_input_config();
+struct Input_Config* game_make_temp_input_config();
+void game_apply_temp_input_config();
+b32 game_input_config_has_changed();
+void game_input_config_save();
+void game_input_config_load();
 void game_update_input();
+
 void game_update(void* udata);
 void game_draw();
 

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -1,6 +1,24 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+typedef s32 Input_Mod;
+enum
+{
+    Input_Mod_None = 0,
+    Input_Mod_Control = 1 << 0,
+    Input_Mod_Shift = 1 << 1,
+    Input_Mod_Alt = 1 << 2,
+    Input_Mod_Gui = 1 << 3,
+};
+
+typedef struct Input_Binding
+{
+    b32 is_mouse_button;
+    Input_Mod mod;
+    CF_KeyButton key;
+    CF_MouseButton mouse;
+} Input_Binding;
+
 typedef s32 Input_Multiselect_State;
 enum
 {
@@ -9,6 +27,12 @@ enum
     Input_Multiselect_State_Commit,
     Input_Multiselect_State_Finish,
 };
+
+typedef struct Input_Config
+{
+    dyna Input_Binding* move;
+    dyna Input_Binding* fire;
+} Input_Config;
 
 typedef struct Input
 {
@@ -19,9 +43,13 @@ typedef struct Input
     V2i tile_select_end;
     
     b32 is_holding_add_remove;
-    b32 move;
     b32 select;
+    b32 move;
     b32 fire;
+    
+    // keyboard/controller
+    V2i move_direction;
+    
     Input_Multiselect_State multiselect;
     mco_coro* multiselect_co;
 } Input;
@@ -40,5 +68,8 @@ b32 input_binding_list_just_pressed(dyna Input_Binding* bindings);
 b32 input_binding_list_just_released(dyna Input_Binding* bindings);
 CF_KeyButton get_any_key();
 CF_MouseButton get_any_mouse();
+
+b32 input_config_save(const char** names, Input_Binding** binding_list, s32 count, const char* output_file);
+b32 input_config_load(const char** names, Input_Binding** binding_list, s32 count, const char* input_file);
 
 #endif //INPUT_H


### PR DESCRIPTION
when adding in option to mount root directory it caused a vfs leak so file dialog was broken, it is now fixed and areas with root mounting to read/write configs are dismounted afterwards.
added input configs for main game
unit when stopping after firing should properly stop on the correct tile, it wasn't being updated properly causing a 1 off tile and this made things such as `on_touch` to not fire correctly
