### PR TITLE
initial digital input test

### DIFF
--- a/src/game/game_ui.c
+++ b/src/game/game_ui.c
@@ -1703,12 +1703,20 @@ void game_ui_do_options_input_game(f32 largest_width)
     const char* input_names[] =
     {
         "Move",
+        "Move Up",
+        "Move Down",
+        "Move Left",
+        "Move Right",
         "Fire",
     };
     
     Input_Binding* input_bindings[] =
     {
         input_config->move,
+        input_config->move_up,
+        input_config->move_down,
+        input_config->move_left,
+        input_config->move_right,
         input_config->fire,
     };
     
@@ -1951,6 +1959,10 @@ void game_ui_do_options_input()
     {
         // game
         "Move",
+        "Move Up",
+        "Move Down",
+        "Move Left",
+        "Move Right",
         "Fire",
         // editor
         "Place",

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -31,6 +31,10 @@ enum
 typedef struct Input_Config
 {
     dyna Input_Binding* move;
+    dyna Input_Binding* move_up;
+    dyna Input_Binding* move_down;
+    dyna Input_Binding* move_left;
+    dyna Input_Binding* move_right;
     dyna Input_Binding* fire;
 } Input_Config;
 
@@ -48,6 +52,7 @@ typedef struct Input
     b32 fire;
     
     // keyboard/controller
+    V2i prev_move_direction;
     V2i move_direction;
     
     Input_Multiselect_State multiselect;


### PR DESCRIPTION
testing out digital input, this one has it so it looks like the following
```
#w#
a#d
#s#
```
so wasd/up down left right will move you at diagonals, feels a bit clunky but this is mostly due to the players moving tile by tile instead of some bits of the tile.

this is a start but can work if we allow fractional movements instead of whole but at the moment it's fairly clunky.