### PR TITLE
submit background in it's own draw call before smaller sprites

### DIFF
--- a/src/game/draw.c
+++ b/src/game/draw.c
@@ -137,10 +137,6 @@ void draw_sort()
 {
     World* world = s_app->world;
     dyna Draw_Command* commands = world->draw.commands;
-    //  @todo:  whatever msvc implemention of qsort is it's really bad
-    //          don't know how well clang, gcc or mingw qsort handles it but this needs to go yesterday
-    //          write a radix sort or something because filling a 20x20 grid blows up the memory
-    //          usage from 600mb (yeah that's pretty big for a start up) to 12 gb (excuse me?!)
     qsort(commands, cf_array_count(commands), sizeof(Draw_Command), draw_command_compare);
 }
 

--- a/src/game/entity.c
+++ b/src/game/entity.c
@@ -1511,6 +1511,7 @@ void world_draw()
     draw_push_layer(0);
     
     ecs_update_system(ecs, ECS_GET_SYSTEM_ID(system_draw_background), CF_DELTA_TIME);
+    draw_push_layer(1);
     ecs_update_system(ecs, ECS_GET_SYSTEM_ID(system_draw_setup_camera), CF_DELTA_TIME);
     ecs_update_system(ecs, ECS_GET_SYSTEM_ID(system_draw_level_tile), CF_DELTA_TIME);
     if (world->debug.show_ai_view_cone)
@@ -5683,6 +5684,7 @@ ecs_ret_t system_draw_background(ecs_t* ecs, ecs_id_t* entities, int entity_coun
             background->scale = scale;
         }
         cf_draw_sprite(background);
+        cf_render_to(cf_app_get_canvas(), true);
     }
     
     return 0;
@@ -6233,7 +6235,7 @@ ecs_ret_t system_draw_canvas_composite(ecs_t* ecs, ecs_id_t* entities, int entit
     draw_push_all();
     cf_draw_pop();
     
-    cf_render_to(cf_app_get_canvas(), true);
+    cf_render_to(cf_app_get_canvas(), s_app->world->level.background ? false : true);
     
     return 0;
 }


### PR DESCRIPTION
if we have a large texture that's in flight with smaller ones on different atlases then this can cause a lot of memory allocations during `cf_render_to()`.
for now have the background in it's own draw call to prevent all of these allocations and initial hitch, this also reduces total draw calls due to pipeline / texture lookups as well.