### PR TITLE
assets_watcher runs every 10 frames

### DIFF
--- a/src/assets/assets.c
+++ b/src/assets/assets.c
@@ -1558,12 +1558,20 @@ Asset_Resource load_asset_resource(const char* path, pq const char*** sprite_fil
 
 void assets_watch_resources()
 {
+    static s32 watch_counter = ASSETS_WATCH_COUNTER;
+    
     if (!s_app->assets)
     {
         s_app->assets = cf_calloc(sizeof(Assets), 1);
         s_app->assets->rnd = cf_rnd_seed(cf_get_tick_frequency());
     }
     Assets* assets = s_app->assets;
+    
+    if (watch_counter++ < ASSETS_WATCH_COUNTER)
+    {
+        return;
+    }
+    watch_counter -= ASSETS_WATCH_COUNTER;
     
     mount_data_read_directory();
     

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -32,6 +32,8 @@ DATA[__length] = '\0'; \
 #define LEVEL_FILE_TYPE_SUFFIX ".ipl"
 #endif
 
+#define ASSETS_WATCH_COUNTER (10)
+
 // used for tile and object layer maps, this will map from runtime asset ids to
 // local ones to each level save file
 typedef s32 Asset_Object_ID;


### PR DESCRIPTION
`C_Switch` can now be attached to units to trigger `on_touch` rather than only to be triggered `on_dead`.