### PR TITLE
controllers can switch between units with left and right trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ imgui.ini
 *.gif
 editor_config.json
 input_config.json
-app_config.json
+controller_config.json
+settings.json

--- a/src/game/entity.c
+++ b/src/game/entity.c
@@ -2670,7 +2670,6 @@ ecs_ret_t system_handle_events(ecs_t* ecs, ecs_id_t* entities, int entity_count,
             break;
             case Event_Type_Do_Select_Control_Unit:
             {
-                
                 ecs_id_t select_entity = event->select_control_unit.entity;
                 if (ecs_is_ready(ecs, select_entity) && ecs_has(ecs, select_entity, component_control_id))
                 {
@@ -3490,6 +3489,16 @@ ecs_ret_t system_update_control_unit_selection(ecs_t* ecs, ecs_id_t* entities, i
     Input* input = s_app->input;
     World* world = s_app->world;
     
+    s32 selection_direction = 0;
+    if (input->select_next)
+    {
+        selection_direction = 1;
+    }
+    if (input->select_prev)
+    {
+        selection_direction = -1;
+    }
+    
     ecs_id_t component_control_id = ECS_GET_COMPONENT_ID(C_Control);
     ecs_id_t component_unit_transform_id = ECS_GET_COMPONENT_ID(C_Unit_Transform);
     
@@ -3648,6 +3657,33 @@ ecs_ret_t system_update_control_unit_selection(ecs_t* ecs, ecs_id_t* entities, i
                 pq_add(control_order, entity, 0);
                 make_event_on_select_control_unit(entity);
                 break;
+            }
+        }
+        
+        if (selection_direction != 0)
+        {
+            if (pq_count(control_order) > 0)
+            {
+                for (s32 index = 0; index < entity_count; ++index)
+                {
+                    ecs_id_t entity = entities[index];
+                    if (entity == control_order[0])
+                    {
+                        s32 next_select_index = (index + selection_direction + entity_count) % entity_count;
+                        
+                        pq_clear(control_order);
+                        pq_add(control_order, entities[next_select_index], 0);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                if (entity_count)
+                {
+                    pq_clear(control_order);
+                    pq_add(control_order, entities[0], 0);
+                }
             }
         }
     }

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -741,6 +741,49 @@ CF_V2 controller_get_axis_prev(Controller_Joypad_Axis type)
     return axis;
 }
 
+V2i controller_get_digital_input_from_axis(Controller_Joypad_Axis type, b32 repeat, f32 threshold)
+{
+    CF_V2 axis = controller_get_axis(type);
+    CF_V2 prev_axis = cf_v2(0, 0);
+    if (!repeat)
+    {
+        prev_axis = controller_get_axis_prev(type);
+    }
+    
+    V2i digital_axis = v2i();
+    
+    if (axis.y > threshold)
+    {
+        if (prev_axis.y < threshold)
+        {
+            digital_axis.y += 1;
+        }
+    }
+    if (axis.y < -threshold)
+    {
+        if (prev_axis.y > -threshold)
+        {
+            digital_axis.y -= 1;
+        }
+    }
+    if (axis.x > threshold)
+    {
+        if (prev_axis.x < threshold)
+        {
+            digital_axis.x += 1;
+        }
+    }
+    if (axis.x < -threshold)
+    {
+        if (prev_axis.x > -threshold)
+        {
+            digital_axis.x -= 1;
+        }
+    }
+    
+    return digital_axis;
+}
+
 b32 controller_config_save(const char** names, CF_JoypadButton* buttons, s32 count, 
                            CF_Aabb left_dead_zone, CF_Aabb right_dead_zone, f32 aim_sensitivity,
                            const char* output_file)
@@ -895,4 +938,15 @@ b32 controller_config_load(const char** names, CF_JoypadButton** buttons, s32 co
     cf_destroy_json(doc);
     
     return success;
+}
+
+CF_JoypadType controller_get_type()
+{
+    CF_JoypadType type = CF_JOYPAD_TYPE_COUNT;
+    if (cf_joypad_count() > 0)
+    {
+        s32 joypad_index = 0;
+        type = cf_joypad_type(joypad_index);
+    }
+    return type;
 }

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -61,6 +61,11 @@ typedef struct Controller_Input_Config
     CF_JoypadButton move_left;
     CF_JoypadButton move_right;
     CF_JoypadButton fire;
+    
+    //  @todo:  left and right trigger right now is used to select next and prev controllable units
+    //          this needs to be remappable by the player
+    //          so change CF_JoypadButton to include triggers
+    
 } Controller_Input_Config;
 
 typedef struct Input
@@ -75,6 +80,8 @@ typedef struct Input
     b32 select;
     b32 move;
     b32 fire;
+    b32 select_next;
+    b32 select_prev;
     
     // keyboard/controller
     V2i prev_move_direction;
@@ -82,7 +89,7 @@ typedef struct Input
     
     CF_V2 aim_direction;
     
-    //  @todo:  store last control type, keyboard/mouse or controller as well as controller type
+    CF_JoypadType controller_type;
     
     Input_Multiselect_State multiselect;
     mco_coro* multiselect_co;
@@ -124,6 +131,7 @@ enum
 
 CF_V2 controller_get_axis(Controller_Joypad_Axis type);
 CF_V2 controller_get_axis_prev(Controller_Joypad_Axis type);
+V2i controller_get_digital_input_from_axis(Controller_Joypad_Axis type, b32 repeat, f32 threshold);
 
 b32 controller_config_save(const char** names, CF_JoypadButton* buttons, s32 count, 
                            CF_Aabb left_dead_zone, CF_Aabb right_dead_zone, f32 aim_sensitivity,
@@ -131,5 +139,7 @@ b32 controller_config_save(const char** names, CF_JoypadButton* buttons, s32 cou
 b32 controller_config_load(const char** names, CF_JoypadButton** buttons, s32 count, 
                            CF_Aabb* left_dead_zone, CF_Aabb* right_dead_zone, f32* aim_sensitivity,
                            const char* input_file);
+
+CF_JoypadType controller_get_type();
 
 #endif //INPUT_H


### PR DESCRIPTION
minor fix includes controller and keyboard inputs no longer getting stuck when transitioning menus, such as options -> slider -> back to main menu, this would cause you to not be able to navigate through the menu because you're hovering over a ui element that's no longer drawn.