### PR TITLE
slider can be adjusted while not in bounds

### DIFF
--- a/src/game/editor.c
+++ b/src/game/editor.c
@@ -352,7 +352,7 @@ void editor_input_update()
         remove = input_binding_list_just_released(editor_input_config->remove);
     }
     
-    if (game_ui_is_hovering_over_any_layouts() || ui_is_any_selected())
+    if (game_ui_is_hovering_over_any_layouts(input->screen_mouse) || ui_is_any_selected())
     {
         place = false;
         remove = false;

--- a/src/game/editor_ui.c
+++ b/src/game/editor_ui.c
@@ -1401,7 +1401,11 @@ void editor_ui_do_footer()
 
 void editor_ui_do_main()
 {
-    CLAY(CLAY_ID("Editor_OuterContainer"), {
+    Game_UI* game_ui = s_app->game_ui;
+    
+    Clay_ElementId editor_outer_container_id = CLAY_ID("Editor_OuterContainer");
+    
+    CLAY(editor_outer_container_id, {
              .backgroundColor = { 128, 128, 128, 255 },
              .layout = {
                  .layoutDirection = CLAY_TOP_TO_BOTTOM,
@@ -1416,7 +1420,7 @@ void editor_ui_do_main()
              },
          })
     {
-        Clay_OnHover(clay_on_hover, 0);
+        cf_array_push(game_ui->blocking_ids, editor_outer_container_id);
         
         Editor_Tab_Type tab_type = editor_ui_do_tabs();
         

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -626,7 +626,7 @@ void game_update_input()
         aim_direction = cf_v2(0, 0);
     }
     
-    if (game_ui_is_hovering_over_any_layouts())
+    if (game_ui_is_hovering_over_any_layouts(screen_mouse))
     {
         tile_select = v2i(.x = -1, .y = -1);
         // allow controller to still fire while hovering over UI

--- a/src/game/game_ui.h
+++ b/src/game/game_ui.h
@@ -52,9 +52,7 @@ typedef struct Game_UI
     // level name
     fixed char* level_name;
     
-    //  @todo:  fix this so only 1 is needed
-    Clay_ElementId hover_id;
-    Clay_ElementId prev_hover_id;
+    dyna Clay_ElementId* blocking_ids;
 } Game_UI;
 
 void game_ui_handle_state(Game_UI_State state, Game_UI_State next_state);
@@ -67,17 +65,13 @@ void game_ui_control_add(ecs_id_t id);
 void game_ui_control_remove(ecs_id_t id);
 void game_ui_control_clear(ecs_id_t id);
 
-// use this to have tile selection disabled when hovering over UI layouts
-// Clay_OnHover(clay_on_hover, 0)
-void clay_on_hover(Clay_ElementId elementId, Clay_PointerData pointerData, intptr_t userData);
-
 void game_ui_play_button_sound();
 
 b32 game_ui_do_button(const char* text);
 b32 game_ui_do_button_wide(const char* text);
 b32 game_ui_do_image_button(const char* name, const char* animation, CF_V2 size);
 b32 game_ui_do_sprite_button(CF_Sprite* sprite, CF_V2 size);
-b32 game_ui_is_hovering_over_any_layouts();
+b32 game_ui_is_hovering_over_any_layouts(CF_V2 mouse);
 
 void game_ui_set_item_tooltip(const char* fmt, ...);
 b32 game_ui_do_file_dialog_co_ex(mco_coro* co);


### PR DESCRIPTION
cleaned up `game_ui_is_hovering_over_any_layouts()` logic a bit so it's only applies to `Clay_ElementId` layout bounds rather than arbitrary ids.
added `blocking_ids` to `Game_UI`, these are used to handle the above hovering checks to disable mouse interactions while hovering over these id regions.
removed `clay_on_hovering()` this wasn't accurate and made things more complicated.
adjusted default `select_color` ui style so it's more noticeable.